### PR TITLE
add secret key needed for /register action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ idletimeout : 60000                  # Time to wait before closing idle connecti
 #whitelist :                         # Allowed destinations  ( allow all if empty )
 # - method : "^GET$"                 #   Applied in order after blacklist
 #   url : "^http(s)?://.*"           #   One must match
-
+# secretkey : ThisIsASecret          # secret key that must be set in clients configuration
 ```
 
 ```
@@ -83,6 +83,7 @@ poolmaxsize : 100                    # Maximum number of concurrent open (TCP) c
 #whitelist :                         # Allowed destinations  ( allow all if empty )
 # - method : "^GET$"                 #   Applied in order after blacklist
 #   url : "^https://.*"              #   One must match
+# secretkey : ThisIsASecret          # secret key that must match the value set in servers configuration
 ```
 
  - poolMinSize is the default number of opened TCP/HTTP/WS connections

--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,7 @@ func NewClient(config *Config) (c *Client) {
 // Start the Proxy
 func (c *Client) Start() {
 	for _, target := range c.Config.Targets {
-		pool := NewPool(c, target)
+		pool := NewPool(c, target, c.Config.SecretKey)
 		c.pools[target] = pool
 		go pool.Start()
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	PoolMaxSize  int
 	Whitelist    []*common.Rule
 	Blacklist    []*common.Rule
+	SecretKey    string
 }
 
 // NewConfig creates a new ProxyConfig

--- a/client/connection.go
+++ b/client/connection.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -41,7 +42,8 @@ func (connection *Connection) Connect() (err error) {
 	log.Printf("Connecting to %s", connection.pool.target)
 
 	// Create a new TCP(/TLS) connection ( no use of net.http )
-	connection.ws, _, err = connection.pool.client.dialer.Dial(connection.pool.target, nil)
+	connection.ws, _, err = connection.pool.client.dialer.Dial(connection.pool.target, http.Header{"X-SECRET-KEY": {connection.pool.secretKey}})
+
 	if err != nil {
 		return err
 	}

--- a/client/pool.go
+++ b/client/pool.go
@@ -9,8 +9,9 @@ import (
 
 // Pool manage a pool of connection to a remote Server
 type Pool struct {
-	client *Client
-	target string
+	client    *Client
+	target    string
+	secretKey string
 
 	connections []*Connection
 	lock        sync.RWMutex
@@ -19,11 +20,12 @@ type Pool struct {
 }
 
 // NewPool creates a new Pool
-func NewPool(client *Client, target string) (pool *Pool) {
+func NewPool(client *Client, target string, secretKey string) (pool *Pool) {
 	pool = new(Pool)
 	pool.client = client
 	pool.target = target
 	pool.connections = make([]*Connection, 0)
+	pool.secretKey = secretKey
 	pool.done = make(chan struct{})
 	return
 }

--- a/server/config.go
+++ b/server/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	IdleTimeout int
 	Whitelist   []*common.Rule
 	Blacklist   []*common.Rule
+	SecretKey   string
 }
 
 // NewConfig creates a new ProxyConfig

--- a/server/server.go
+++ b/server/server.go
@@ -240,6 +240,12 @@ func (server *Server) request(w http.ResponseWriter, r *http.Request) {
 
 // This is the way for IzolatorProxies to offer websocket connections
 func (server *Server) register(w http.ResponseWriter, r *http.Request) {
+	secretKey := r.Header.Get("X-SECRET-KEY")
+	if secretKey != server.Config.SecretKey {
+		common.ProxyErrorf(w, "Invalid X-SECRET-KEY")
+		return
+	}
+
 	ws, err := server.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		common.ProxyErrorf(w, "HTTP upgrade error : %v", err)

--- a/wsp_client/wsp_client.cfg
+++ b/wsp_client/wsp_client.cfg
@@ -9,3 +9,4 @@ poolmaxsize : 100                    # Maximum number of concurrent open (TCP) c
 #whitelist :                         # Allowed destinations  ( allow all if empty )
 # - method : "^GET$"                 #   Applied in order after blacklist
 #   url : "^https://.*"              #   One must match
+# secretkey : ThisIsASecret          # secret key that must match the value set in servers configuration

--- a/wsp_server/wsp_server.cfg
+++ b/wsp_server/wsp_server.cfg
@@ -9,3 +9,4 @@ idletimeout : 60000                  # Time to wait before closing idle connecti
 #whitelist :                         # Allowed destinations  ( allow all if empty )
 # - method : "^GET$"                 #   Applied in order after blacklist
 #   url : "^http(s)?://.*"           #   One must match
+# secretkey : ThisIsASecret          # secret key that must be set in clients configuration


### PR DESCRIPTION
This adds a secret key config setting that can be set in the server and client configs.
When set, then only when the secret key matches in the server and client configurations will clients be allowed to register